### PR TITLE
GPII-4140: Update to node12 and renamed as scoped package @gpii/ref-struct

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "c++",
     "ffi"
   ],
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {
     "type": "git",
@@ -18,16 +18,16 @@
   "main": "./lib/struct.js",
   "license": "MIT",
   "scripts": {
-    "test": "node-gyp rebuild --directory test && mocha -gc --reporter spec"
+    "test": "node-gyp rebuild --directory test && mocha -gc-global --expose-gc --reporter spec"
   },
   "dependencies": {
-    "debug": "2",
-    "ref": "1"
+    "debug": "4",
+    "ref": "lxe/ref#node-12"
   },
   "devDependencies": {
-    "bindings": "~1.2.0",
+    "bindings": "~1.5.0",
     "nan": "2",
     "mocha": "*",
-    "ref-array": "~1.1.2"
+    "ref-array": "lxe/ref-array#node-12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "debug": "4",
-    "@gpii/ref": "2.0.0"
+    "ref": "javihernandez/ref#GPII-4140"
   },
   "devDependencies": {
     "bindings": "~1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ref-struct",
+  "name": "@gpii/ref-struct",
   "description": "Create ABI-compliant \"struct\" instances on top of Buffers",
   "keywords": [
     "struct",
@@ -13,7 +13,7 @@
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {
     "type": "git",
-    "url": "git://github.com/TooTallNate/ref-struct.git"
+    "url": "git://github.com/GPII/ref-struct.git"
   },
   "main": "./lib/struct.js",
   "license": "MIT",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "debug": "4",
-    "ref": "javihernandez/ref#node-12"
+    "@gpii/ref": "2.0.0"
   },
   "devDependencies": {
     "bindings": "~1.5.0",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   },
   "dependencies": {
     "debug": "4",
-    "ref": "lxe/ref#node-12"
+    "ref": "javihernandez/ref#node-12"
   },
   "devDependencies": {
     "bindings": "~1.5.0",
     "nan": "2",
     "mocha": "*",
-    "ref-array": "lxe/ref-array#node-12"
+    "ref-array": "javihernandez/ref-array#node-12"
   }
 }


### PR DESCRIPTION
Depends on https://github.com/GPII/ref/pull/1